### PR TITLE
Support for local/non-local checks on AIX and Darwin

### DIFF
--- a/linux/log4j_findings.sh
+++ b/linux/log4j_findings.sh
@@ -141,7 +141,7 @@ log4j()
     if [ $NETDIR_SCAN = true ];then
         jars=$(find ${BASEDIR} -type f -regextype posix-egrep -iregex ".+\.(jar|war|ear|zip)$"  2> /dev/null); 
     else
-	jars=$(find ${BASEDIR} -type f -regextype posix-egrep -iregex ".+\.(jar|war|ear|zip)$"  ! -fstype nfs ! -fstype nfs4 ! -fstype cifs ! -fstype smbfs ! -fstype gfs ! -fstype gfs2 ! -fstype safenetfs ! -fstype secfs ! -fstype gpfs ! -fstype smb2 ! -fstype vxfs ! -fstype vxodmfs ! -fstype afs -print 2>/dev/null);
+        jars=$(find ${BASEDIR} -type f -regextype posix-egrep -iregex ".+\.(jar|war|ear|zip)$"  ! -fstype nfs ! -fstype nfs4 ! -fstype cifs ! -fstype smbfs ! -fstype gfs ! -fstype gfs2 ! -fstype safenetfs ! -fstype secfs ! -fstype gpfs ! -fstype smb2 ! -fstype vxfs ! -fstype vxodmfs ! -fstype afs -print 2>/dev/null);
     fi 
 	
     	IFS=$'\n'

--- a/unix/log4j_findings_unix.sh
+++ b/unix/log4j_findings_unix.sh
@@ -2,8 +2,17 @@
 
 if [ $# -eq 0 ]; then
 	BASEDIR="/";
+	NETDIR_SCAN=false;
 elif [ $# -eq 1 ]; then
 	BASEDIR=$1;
+	if [ ! -d $BASEDIR ]; then
+		echo "Please enter valid directory path";
+		exit 1;
+	fi;
+	NETDIR_SCAN=false
+elif [ $# -eq 2 ]; then
+	BASEDIR=$1
+	NETDIR_SCAN=$2
 	if [ ! -d $BASEDIR ]; then
 		echo "Please enter valid directory path";
 		exit 1;
@@ -37,9 +46,23 @@ log4j()
 		mkdir -p /tmp/log4j_jar;
 	fi;	
 	
-	cd /tmp/log4j_jar 2>/dev/null	
-	
-	jars=$(find ${BASEDIR} -follow -name "*.jar" -type f 2>/dev/null)
+	cd /tmp/log4j_jar 2>/dev/null
+
+	if [ "${OS}" = "AIX" ]; then
+	  if [ $NETDIR_SCAN = false ]; then
+	    jars=$(find ${BASEDIR} -follow -type f -name "*.jar" ! -fstype nfs ! fstype procfs 2>/dev/null)
+	  else
+	    jars=$(find ${BASEDIR} -follow -type f -name "*.jar" ! -fstype procfs 2>/dev/null)
+	  fi
+	elif [ "${OS}" = "Darwin" ]; then
+	  if [ "$NETDIR_SCAN" = false ]; then
+	    jars=$(find ${BASEDIR} -follow -type f -name "*.jar" -fstype local 2>/dev/null)
+	  else
+	    jars=$(find ${BASEDIR} -follow -type f -name "*.jar" 2>/dev/null)
+	  fi
+	fi
+
+	# jars=$(find ${BASEDIR} -follow -name "*.jar" -type f 2>/dev/null)
 	
 	for i in $jars;	do
 		if test=$(jar -tf $i | grep "[l]og4j-core" | grep "pom.xml" 2>/dev/null); then


### PR DESCRIPTION
Small formatting change to the linux script (reset the indent on line 144 to make it readable again, has no functional impact)

Added AIX- and Darwin-specific find commands because the method of running local vs. network scans is different.  AIX uses explicit exclusion, MacOS uses implicit exclusion.